### PR TITLE
`provide` method not called on `DependencyInjection` subclasses

### DIFF
--- a/CBInjection/Models/DependencyInjection.swift
+++ b/CBInjection/Models/DependencyInjection.swift
@@ -11,7 +11,7 @@ open class DependencyInjection<T> {
     ///     - dependencies: provider for resolving other dependencies
     ///
     /// - Returns: Instance of the requested dependency or an error is thrown
-    func provide(using _: Dependencies, parameters _: [InjectionParameterName: Any]) throws -> T {
+    open func provide(using _: Dependencies, parameters _: [InjectionParameterName: Any]) throws -> T {
         throw DependenciesError.injectionNotImplemented
     }
 }

--- a/CBInjectionTests/DependenciesTests.swift
+++ b/CBInjectionTests/DependenciesTests.swift
@@ -1,6 +1,6 @@
 // Copyright (c) 2017-2019 Coinbase Inc. See LICENSE
 
-@testable import CBInjection
+import CBInjection
 import XCTest
 
 private let expectedName = "Notorious B.I.G."


### PR DESCRIPTION
Clients could not override the `provide` method since it was not marked `open`.