### PR TITLE
Allow key replacement for unit tests

### DIFF
--- a/CBInjection/Dependency/Dependencies.swift
+++ b/CBInjection/Dependency/Dependencies.swift
@@ -12,13 +12,27 @@ public final class Dependencies {
     /// Holds on to cached singletons
     private var cache = [InjectionKeys: Any]()
 
+    /// Keep internal. Used to cache injection key overrides in unit tests
+    internal var injectionKeyOverrides = [InjectionKeys: InjectionKeys]()
+
+    /// Keep internal. Used to override injection keys in unit tests
+    ///
+    /// - Parameters:
+    ///     - key: The original key to override
+    ///     - overrideKey: The override injection key
+    internal func replace<T>(key: InjectionKey<T>, with overrideKey: InjectionKey<T>) {
+        injectionKeyOverrides[key] = overrideKey
+    }
+
     /// Get injection for given injection key
     ///
     /// - Parameters:
-    ///     - key: Key specifying type of injection
+    ///     - injectionKey: Key specifying type of injection
     ///
     /// - Returns: Instance of the requested dependency or an error is thrown
-    public func provide<T>(_ key: InjectionKey<T>) throws -> T {
+    public func provide<T>(_ injectionKey: InjectionKey<T>) throws -> T {
+        let key = (injectionKeyOverrides[injectionKey] as? InjectionKey<T>) ?? injectionKey
+
         switch key.scope {
         case .singleton:
             singletonLock.lock()

--- a/CBInjectionTests/DependenciesTests.swift
+++ b/CBInjectionTests/DependenciesTests.swift
@@ -1,6 +1,6 @@
 // Copyright (c) 2017-2019 Coinbase Inc. See LICENSE
 
-import CBInjection
+@testable import CBInjection
 import XCTest
 
 private let expectedName = "Notorious B.I.G."
@@ -105,6 +105,24 @@ class DependenciesTests: XCTestCase {
         XCTAssertEqual(expectedName, actual2.transientDep.name)
 
         XCTAssertNotEqual(actual.uuid, actual2.uuid)
+    }
+
+    func testInjectioReplacement() throws {
+        let deps = Dependencies()
+        let expectedResolvedString = "Hello World"
+        let originalKey = InjectionKey<String>(scope: .transient) { _ in
+            return "OriginalKey"
+        }
+
+        let replacementKey = InjectionKey<String>(scope: .transient) { _ in
+            return expectedResolvedString
+        }
+
+        deps.replace(key: originalKey, with: replacementKey)
+
+        let actual = try deps.provide(originalKey)
+
+        XCTAssertEqual(expectedResolvedString, actual)
     }
 }
 


### PR DESCRIPTION
Due to the complex nature of the app, we need a way to inject mocks in Unit Tests. This PR adds that support by exposing an `internal` replace method. It's `internal` for two reasons:
1. Prevent key replacement by apps using CBInjection API
1. Allow the method to be accessible from unit tests by importing `@testable import CBInjection`. 